### PR TITLE
[TDO-143] Add 'hard-to-guess' header to whitelist via regex in WAF

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -20,6 +20,11 @@ abstract class Command
     const ARG_TYPE_DATETIME = 'datetime';
 
     /**
+     * The custom header that identifies requests from the SDK to the application firewall
+     */
+    const CUSTOM_FIREWALL_HEADER = 'X-Serato-Firewall';
+
+    /**
      * Client application ID
      *
      * @var string
@@ -82,6 +87,7 @@ abstract class Command
     public function getRequest(): RequestInterface
     {
         $this->validateCommandArgs();
+        $this->setFirewallRequestHeader();
         $this->setCommandRequestHeaders();
         return new Request(
             $this->getHttpMethod(),
@@ -159,6 +165,17 @@ abstract class Command
             }
         }
         return http_build_query($stringArgs);
+    }
+
+    /**
+     * Sets a custom request header for the Command that identifies the request to the application firewall.
+     *
+     * @return Command The current command, with the firewall request header set
+     */
+    protected function setFirewallRequestHeader(): self
+    {
+        $firewallHeader = new FirewallHeader();
+        return $this->setRequestHeader(self::CUSTOM_FIREWALL_HEADER, $firewallHeader->getHeaderValue());
     }
 
     /**

--- a/src/FirewallHeader.php
+++ b/src/FirewallHeader.php
@@ -40,8 +40,14 @@ class FirewallHeader
      */
     private $timeStamp;
 
+    /**
+     * @var string Three letter prefix for the firewall header, from the set of PREFIX_CHARACTERS letters
+     */
+    private $prefix;
+
     public function __construct()
     {
+        $this->prefix = substr(str_shuffle(self::PREFIX_CHARACTERS),-3);
         $this->timeStamp = (new DateTime())->format(DateTime::ATOM);
     }
 
@@ -54,10 +60,9 @@ class FirewallHeader
      */
     public function getHeaderValue(): string
     {
-        $prefix = substr(str_shuffle(self::PREFIX_CHARACTERS),-3);
         $hash = $this->getHeaderHash($this->timeStamp);
 
-        return $prefix . '~' . $hash;
+        return $this->prefix . '~' . $hash;
     }
 
     private function getHeaderHash(string $textToHash): string

--- a/src/FirewallHeader.php
+++ b/src/FirewallHeader.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types=1);
+
+namespace Serato\SwsSdk;
+
+use DateTime;
+
+/**
+ * Class FirewallHeader
+ *
+ * Represents a strategy for generating a header that identifies Serato applications to the firewall. This header should
+ * be non-trivial to guess by outsiders (unless they find this repository). If we wanted to make this header harder to
+ * guess, we could introduce an environment variable that isn't present in the source code.
+ *
+ * @package Serato\SwsSdk
+ */
+class FirewallHeader
+{
+    /**
+     * The values by which ordinal values of the ASCII characters in each 8-character chunk of the md5 hash will be
+     * shifted (with the intention of making the strategy for generating the header less guessable, while still allowing
+     * the header to be easily matched by a regular expression)
+     */
+    public const SHIFTS = [-8, 8, -16, 16];
+
+    /**
+     * In another effort to make the header less guessable by people curious enough to make requests to our test servers
+     * (but not curious enough to look at this open source code), add a prefix with characters drawn from a specific set
+     * to the header
+     */
+    public const PREFIX_CHARACTERS = 'serato';
+
+    /**
+     * Regular expression pattern that will match valid firewall header lines
+     */
+    public const HEADER_PATTERN = '/[serato]{3}~[\x28-\x31\x59-\x5E]{8}[\x38-\x41\x69-\x6E]{8}[\x20-\x29\x51-\x56]{8}[\x40-\x49\x71-\x76]{8}/';
+
+    /**
+     * @var string Date/time at which this header was created (used to create the hash)
+     */
+    private $timeStamp;
+
+    public function __construct()
+    {
+        $this->timeStamp = (new DateTime())->format(DateTime::ATOM);
+    }
+
+    /**
+     * Returns a header value consisting of:
+     * 1. A 3 character prefix drawn from characters in the PREFIX_CHARACTERS string with no repeats, and
+     * 2. A hash, with every 8 ASCII character chunk shifted by the offsets defined in the SHIFTS array
+     * - separated by a ~ character.
+     * @return string Header value, for example 'rta~Y[)(/*\,:ijkk>k:S!#R((U$tGvuIstE'
+     */
+    public function getHeaderValue(): string
+    {
+        $prefix = substr(str_shuffle(self::PREFIX_CHARACTERS),-3);
+        $hash = $this->getHeaderHash($this->timeStamp);
+
+        return $prefix . '~' . $hash;
+    }
+
+    private function getHeaderHash(string $textToHash): string
+    {
+        $hash = md5($textToHash);
+        $chunks = str_split($hash, 8);
+        $shiftedHash = '';
+
+        // Shift each chunk's ASCII character values by the corresponding offset in the SHIFTS array
+        foreach ($chunks as $i => $chunk) {
+            $shiftedHash .= $this->shiftChunk($chunk, self::SHIFTS[$i]);
+        }
+
+        return $shiftedHash;
+    }
+
+    private function shiftChunk(string $chunk, int $shift): string
+    {
+        $shiftedChunk = $chunk;
+
+        // Shifts the chunk's (ASCII) characters by the given offset
+        for ($i = 0, $iMax = strlen($chunk); $i < $iMax; $i++) {
+            $shiftedChunk[$i] = $this->shiftCharacter($chunk[$i], $shift);
+        }
+
+        return $shiftedChunk;
+    }
+
+    private function shiftCharacter(string $character, int $shift): string
+    {
+        return chr(ord($character) + $shift);
+    }
+}

--- a/tests/FirewallHeaderTest.php
+++ b/tests/FirewallHeaderTest.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Serato\SwsSdk\Test;
+
+use Serato\SwsSdk\FirewallHeader;
+
+class FirewallHeaderTest extends AbstractTestCase
+{
+    public function testGetHeaderValue(): void
+    {
+        $firewallHeader = new FirewallHeader();
+        $headerValue = $firewallHeader->getHeaderValue();
+
+        // Check that the header returned matches the expected pattern (see comments in FirewallHeader)
+        $this->assertRegExp(FirewallHeader::HEADER_PATTERN, $headerValue);
+    }
+}

--- a/tests/FirewallHeaderTest.php
+++ b/tests/FirewallHeaderTest.php
@@ -15,4 +15,14 @@ class FirewallHeaderTest extends AbstractTestCase
         // Check that the header returned matches the expected pattern (see comments in FirewallHeader)
         $this->assertRegExp(FirewallHeader::HEADER_PATTERN, $headerValue);
     }
+
+    public function testGetHeaderValueTwice(): void
+    {
+        $firewallHeader = new FirewallHeader();
+        $firstHeaderValue = $firewallHeader->getHeaderValue();
+        $secondHeaderValue = $firewallHeader->getHeaderValue();
+
+        // Check that the same header is returned if the value is requested multiple times from the same instance
+        $this->assertEquals($firstHeaderValue, $secondHeaderValue);
+    }
 }


### PR DESCRIPTION
Maybe unnecessarily fiddly, since this is open source and a random string might do as well, but:

- The header starts with 3 characters from [serato]
- After this prefix, there's a ~ character
- The rest of the header is a (32 character) md5 hash of a timestamp, divided into four 8-character chunks. Each of these chunks has the ordinal ASCII values of its characters shifted by an integer (-8, 8, 16, and -16 in sequence) to make it a little harder to guess the pattern

For example: `rta~Y[)(/*\,:ijkk>k:S!#R((U$tGvuIstE`

(Regex: `/[serato]{3}~[\x28-\x31\x59-\x5E]{8}[\x38-\x41\x69-\x6E]{8}[\x20-\x29\x51-\x56]{8}[\x40-\x49\x71-\x76]{8}/`)

This won't stop a motivated 'attacker' from generating this header, but is one way of stopping random people from reconstructing valid requests. We could use an environment variable / stack param / Chef attribute instead if we wanted to make it truly hard to guess.

I've been unable to find any precedents for what we're trying to achieve here online (and also tried appealing to the security and networking communities, who directed me to use a random string / towards the limitations of whitelisting).

Not sure this is the right approach, so I'm opening this as a draft.