### PR TITLE
Bootstrap with service discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,15 @@
 	"type": "library",
 	"require": {
 		"php" : "^7.1",
-		"guzzlehttp/guzzle": "^6.0.0"
+		"guzzlehttp/guzzle": "^6.0.0",
+		"serato/sws-discovery": "^1.0.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~7.0",
 		"squizlabs/php_codesniffer": "~2.0",
 		"aws/aws-sdk-php": "~3.0",
-		"phpstan/phpstan": "^0.11.0",
-		"phpstan/phpstan-phpunit": "^0.11.0"
+		"phpstan/phpstan": "^0.12.0",
+		"phpstan/phpstan-phpunit": "^0.12.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,5 @@ parameters:
     paths:
         - %currentWorkingDirectory%/src
         - %currentWorkingDirectory%/tests
-    includes:
-        - vendor/phpstan/phpstan-phpunit/extension.neon
     excludes_analyse:
         - src/Client.php

--- a/src/Da/DaClient.php
+++ b/src/Da/DaClient.php
@@ -26,7 +26,7 @@ class DaClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/Ecom/Command/InvoiceCreate.php
+++ b/src/Ecom/Command/InvoiceCreate.php
@@ -26,7 +26,7 @@ class InvoiceCreate extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return "/api/v1/orders/{$this->commandArgs['order_id']}/invoice";
+        return '/api/v1/orders/' . self::toString($this->commandArgs['order_id']) . '/invoice';
     }
 
     /**

--- a/src/Ecom/Command/SubscriptionCancel.php
+++ b/src/Ecom/Command/SubscriptionCancel.php
@@ -43,9 +43,9 @@ class SubscriptionCancel extends CommandBasicAuth
     {
         return
             '/api/v1/users/' .
-            $this->commandArgs['user_id'] .
+            self::toString($this->commandArgs['user_id']) .
             '/subscriptions/' .
-            $this->commandArgs['subscription_id'];
+            self::toString($this->commandArgs['subscription_id']);
     }
 
     /**

--- a/src/Ecom/Command/SubscriptionList.php
+++ b/src/Ecom/Command/SubscriptionList.php
@@ -40,7 +40,7 @@ class SubscriptionList extends CommandBasicAuth
     {
         return
             '/api/v1/users/' .
-            $this->commandArgs['user_id'] .
+            self::toString($this->commandArgs['user_id']) .
             '/subscriptions';
     }
 

--- a/src/Ecom/EcomClient.php
+++ b/src/Ecom/EcomClient.php
@@ -29,7 +29,7 @@ class EcomClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/Exception/ResponseException.php
+++ b/src/Exception/ResponseException.php
@@ -17,7 +17,7 @@ use RuntimeException;
  */
 abstract class ResponseException extends RuntimeException
 {
-    /** @var Result  */
+    /** @var Result<String, mixed>  */
     private $result;
 
     public function __construct(BadResponseException $e)
@@ -47,7 +47,7 @@ abstract class ResponseException extends RuntimeException
     /**
      * Return the Result object created from the error response.
      *
-     * @return Result
+     * @return Result<String, mixed>
      */
     public function getResult(): Result
     {

--- a/src/Identity/Command/UserAddGaClientId.php
+++ b/src/Identity/Command/UserAddGaClientId.php
@@ -41,7 +41,7 @@ class UserAddGaClientId extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'] . '/gaclientid';
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']) . '/gaclientid';
     }
 
     /**

--- a/src/Identity/Command/UserGroupAdd.php
+++ b/src/Identity/Command/UserGroupAdd.php
@@ -35,7 +35,7 @@ class UserGroupAdd extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/'. $this->commandArgs['user_id'] . '/groups';
+        return '/api/v1/users/'. self::toString($this->commandArgs['user_id']) . '/groups';
     }
 
     /**

--- a/src/Identity/Command/UserGroupRemove.php
+++ b/src/Identity/Command/UserGroupRemove.php
@@ -38,7 +38,8 @@ class UserGroupRemove extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/'. $this->commandArgs['user_id'] .'/groups/'. $this->commandArgs['group_name'];
+        return '/api/v1/users/'. self::toString($this->commandArgs['user_id']) .
+                '/groups/'. self::toString($this->commandArgs['group_name']);
     }
 
     /**

--- a/src/Identity/Command/UserList.php
+++ b/src/Identity/Command/UserList.php
@@ -50,15 +50,15 @@ class UserList extends CommandBasicAuth
     protected function getArgsDefinition(): array
     {
         return [
-            'email_address' => ['type' => self::ARG_TYPE_STRING],
-            'ga_client_id'  => ['type' => self::ARG_TYPE_STRING],
+            'email_address' => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'ga_client_id'  => ['type' => self::ARG_TYPE_STRING, 'required' => false],
             # Part of the REST API spec, but deliberately ommitted from the
             # PHP docs because:
             # - Hopefully it will be deprecated or removed in the near future, and
             # - I can't think of a legitimate use case for sending it from a server
             #   side application
             # I've only included it for testing purposes
-            'app_session_cookie' => ['type' => self::ARG_TYPE_STRING]
+            'app_session_cookie' => ['type' => self::ARG_TYPE_STRING, 'required' => false]
         ];
     }
 }

--- a/src/Identity/IdentityClient.php
+++ b/src/Identity/IdentityClient.php
@@ -34,7 +34,7 @@ class IdentityClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/License/Command/LicenseList.php
+++ b/src/License/Command/LicenseList.php
@@ -45,7 +45,7 @@ class LicenseList extends CommandBasicAuth
     {
         return
         '/api/v1/users/' .
-        $this->commandArgs['user_id'] .
+        self::toString($this->commandArgs['user_id']) .
         '/licenses';
     }
 
@@ -63,9 +63,9 @@ class LicenseList extends CommandBasicAuth
     protected function getArgsDefinition(): array
     {
         return [
-            'app_name'      => ['type' => self::ARG_TYPE_STRING],
-            'app_version'   => ['type' => self::ARG_TYPE_STRING],
-            'term'          => ['type' => self::ARG_TYPE_STRING],
+            'app_name'      => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'app_version'   => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'term'          => ['type' => self::ARG_TYPE_STRING, 'required' => false],
             'user_id'       => ['type' => self::ARG_TYPE_INTEGER, 'required' => true]
         ];
     }

--- a/src/License/Command/ProductCreate.php
+++ b/src/License/Command/ProductCreate.php
@@ -74,19 +74,19 @@ class ProductCreate extends CommandBasicAuth
     {
         return [
             'product_type_id'           => ['type' => self::ARG_TYPE_INTEGER, 'required' => true],
-            'user_id'                   => ['type' => self::ARG_TYPE_INTEGER],
-            'user_email_address'        => ['type' => self::ARG_TYPE_STRING],
-            'reseller_name'             => ['type' => self::ARG_TYPE_STRING],
-            'created_by_user_id'        => ['type' => self::ARG_TYPE_INTEGER],
-            'nfr'                       => ['type' => self::ARG_TYPE_INTEGER],
-            'notes'                     => ['type' => self::ARG_TYPE_STRING],
-            'valid_to'                  => ['type' => self::ARG_TYPE_DATETIME],
-            'checkout_order_id'         => ['type' => self::ARG_TYPE_INTEGER],
-            'checkout_order_item_id'    => ['type' => self::ARG_TYPE_INTEGER],
-            'magento_order_id'          => ['type' => self::ARG_TYPE_INTEGER],
-            'magento_order_item_id'     => ['type' => self::ARG_TYPE_INTEGER],
-            'subscription_status'       => ['type' => self::ARG_TYPE_STRING],
-            'upgrade_from_product_id'   => ['type' => self::ARG_TYPE_STRING]
+            'user_id'                   => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'user_email_address'        => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'reseller_name'             => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'created_by_user_id'        => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'nfr'                       => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'notes'                     => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'valid_to'                  => ['type' => self::ARG_TYPE_DATETIME, 'required' => false],
+            'checkout_order_id'         => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'checkout_order_item_id'    => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'magento_order_id'          => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'magento_order_item_id'     => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'subscription_status'       => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'upgrade_from_product_id'   => ['type' => self::ARG_TYPE_STRING, 'required' => false]
         ];
     }
 }

--- a/src/License/Command/ProductDelete.php
+++ b/src/License/Command/ProductDelete.php
@@ -30,7 +30,7 @@ class ProductDelete extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/products/products/' . $this->commandArgs['product_id'];
+        return '/api/v1/products/products/' . self::toString($this->commandArgs['product_id']);
     }
 
     /**

--- a/src/License/Command/ProductGet.php
+++ b/src/License/Command/ProductGet.php
@@ -30,7 +30,7 @@ class ProductGet extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/products/products/' . $this->commandArgs['product_id'];
+        return '/api/v1/products/products/' . self::toString($this->commandArgs['product_id']);
     }
 
     /**

--- a/src/License/Command/ProductList.php
+++ b/src/License/Command/ProductList.php
@@ -49,9 +49,9 @@ class ProductList extends CommandBasicAuth
     protected function getArgsDefinition(): array
     {
         return [
-            'checkout_order_id' => ['type' => self::ARG_TYPE_INTEGER],
-            'magento_order_id'  => ['type' => self::ARG_TYPE_INTEGER],
-            'user_id'           => ['type' => self::ARG_TYPE_INTEGER]
+            'checkout_order_id' => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'magento_order_id'  => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'user_id'           => ['type' => self::ARG_TYPE_INTEGER, 'required' => false]
         ];
     }
 }

--- a/src/License/Command/ProductUpdate.php
+++ b/src/License/Command/ProductUpdate.php
@@ -52,7 +52,7 @@ class ProductUpdate extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/products/products/' . $this->commandArgs['product_id'];
+        return '/api/v1/products/products/' . self::toString($this->commandArgs['product_id']);
     }
 
     /**
@@ -70,12 +70,12 @@ class ProductUpdate extends CommandBasicAuth
     {
         return [
             'product_id'                => ['type' => self::ARG_TYPE_STRING, 'required' => true],
-            'valid_to'                  => ['type' => self::ARG_TYPE_DATETIME],
-            'checkout_order_id'         => ['type' => self::ARG_TYPE_INTEGER],
-            'checkout_order_item_id'    => ['type' => self::ARG_TYPE_INTEGER],
-            'magento_order_id'          => ['type' => self::ARG_TYPE_INTEGER],
-            'magento_order_item_id'     => ['type' => self::ARG_TYPE_INTEGER],
-            'subscription_status'       => ['type' => self::ARG_TYPE_STRING]
+            'valid_to'                  => ['type' => self::ARG_TYPE_DATETIME, 'required' => false],
+            'checkout_order_id'         => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'checkout_order_item_id'    => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'magento_order_id'          => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'magento_order_item_id'     => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'subscription_status'       => ['type' => self::ARG_TYPE_STRING, 'required' => false]
         ];
     }
 }

--- a/src/License/LicenseClient.php
+++ b/src/License/LicenseClient.php
@@ -33,7 +33,7 @@ class LicenseClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/Notifications/NotificationsClient.php
+++ b/src/Notifications/NotificationsClient.php
@@ -26,7 +26,7 @@ class NotificationsClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/Profile/Command/UserAddBetaProgram.php
+++ b/src/Profile/Command/UserAddBetaProgram.php
@@ -40,7 +40,7 @@ class UserAddBetaProgram extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'] . '/betaprograms';
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']) . '/betaprograms';
     }
 
     /**

--- a/src/Profile/Command/UserGet.php
+++ b/src/Profile/Command/UserGet.php
@@ -40,7 +40,7 @@ class UserGet extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'];
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']);
     }
 
     /**

--- a/src/Profile/Command/UserGetBetaProgram.php
+++ b/src/Profile/Command/UserGetBetaProgram.php
@@ -41,7 +41,7 @@ class UserGetBetaProgram extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'] . '/betaprograms';
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']) . '/betaprograms';
     }
 
     /**

--- a/src/Profile/Command/UserUpdate.php
+++ b/src/Profile/Command/UserUpdate.php
@@ -52,7 +52,7 @@ class UserUpdate extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'];
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']);
     }
 
     /**
@@ -70,17 +70,17 @@ class UserUpdate extends CommandBasicAuth
     {
         return [
             'user_id'               => ['type' => self::ARG_TYPE_INTEGER, 'required' => true],
-            'global_contact_status' => ['type' => self::ARG_TYPE_INTEGER],
-            'first_name'            => ['type' => self::ARG_TYPE_STRING],
-            'last_name'             => ['type' => self::ARG_TYPE_STRING],
-            'locale'                => ['type' => self::ARG_TYPE_STRING],
-            'address_1'             => ['type' => self::ARG_TYPE_STRING],
-            'address_2'             => ['type' => self::ARG_TYPE_STRING],
-            'city'                  => ['type' => self::ARG_TYPE_STRING],
-            'region'                => ['type' => self::ARG_TYPE_STRING],
-            'postcode'              => ['type' => self::ARG_TYPE_STRING],
-            'country'               => ['type' => self::ARG_TYPE_STRING],
-            'twitch_access_token'   => ['type' => self::ARG_TYPE_STRING],
+            'global_contact_status' => ['type' => self::ARG_TYPE_INTEGER, 'required' => false],
+            'first_name'            => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'last_name'             => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'locale'                => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'address_1'             => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'address_2'             => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'city'                  => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'region'                => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'postcode'              => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'country'               => ['type' => self::ARG_TYPE_STRING, 'required' => false],
+            'twitch_access_token'   => ['type' => self::ARG_TYPE_STRING, 'required' => false],
         ];
     }
 }

--- a/src/Profile/Command/UserValidateAllBetaPrograms.php
+++ b/src/Profile/Command/UserValidateAllBetaPrograms.php
@@ -41,7 +41,7 @@ class UserValidateAllBetaPrograms extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/users/' . $this->commandArgs['user_id'] . '/betaprograms/validateall';
+        return '/api/v1/users/' . self::toString($this->commandArgs['user_id']) . '/betaprograms/validateall';
     }
 
     /**

--- a/src/Profile/ProfileClient.php
+++ b/src/Profile/ProfileClient.php
@@ -33,7 +33,7 @@ class ProfileClient extends Client
      * The key of the array is command's name and the value is the Command
      * class name
      *
-     * @return array
+     * @return array<String, String>
      */
     public function getCommandMap(): array
     {

--- a/src/Result.php
+++ b/src/Result.php
@@ -15,10 +15,13 @@ use Countable;
  *
  * A simple wrapper around a `Psr\Http\Message\ResponseInterface` that parses
  * the response body and exposes it's data via native PHP array accessor syntax.
+ *
+ * @implements IteratorAggregate<String, mixed>
+ * @implements ArrayAccess<String, mixed>
  */
 class Result implements IteratorAggregate, ArrayAccess, Countable
 {
-    /** @var array */
+    /** @var array<String, mixed> */
     private $data = [];
 
     /** @var ResponseInterface */
@@ -40,7 +43,11 @@ class Result implements IteratorAggregate, ArrayAccess, Countable
         return $this->response;
     }
 
-    private function parseResponseBody(ResponseInterface $response)
+    /**
+     * @param ResponseInterface $response
+     * @return null|array<String, mixed>
+     */
+    private function parseResponseBody(ResponseInterface $response): ?array
     {
         if ($response->getStatusCode() !== 204) {
             switch ($response->getHeaderLine('Content-Type')) {
@@ -56,23 +63,33 @@ class Result implements IteratorAggregate, ArrayAccess, Countable
                     throw new Exception($msg);
             }
         }
+        return null;
     }
 
-    private function parseJsonResponseBody(ResponseInterface $response)
+    /**
+     * @param ResponseInterface $response
+     * @return null|array<String, mixed>
+     */
+    private function parseJsonResponseBody(ResponseInterface $response): ?array
     {
         return json_decode((string)$response->getBody(), true);
     }
 
     /**
      * Implementation for `IteratorAggregate` interface
+     *
+     * @return ArrayIterator<String, mixed>
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->data);
     }
 
     /**
      * Implementation for `ArrayAccess` interface
+     *
+     * @param mixed $offset
+     * @return mixed
      */
     public function offsetGet($offset)
     {
@@ -83,6 +100,10 @@ class Result implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * Implementation for `ArrayAccess` interface
+     *
+     * @param mixed $offset
+     * @param mixed $value
+     * @return void
      */
     public function offsetSet($offset, $value)
     {
@@ -91,6 +112,9 @@ class Result implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * Implementation for `ArrayAccess` interface
+     *
+     * @param mixed $offset
+     * @return boolean
      */
     public function offsetExists($offset)
     {
@@ -99,6 +123,9 @@ class Result implements IteratorAggregate, ArrayAccess, Countable
 
     /**
      * Implementation for `ArrayAccess` interface
+     *
+     * @param mixed $offset
+     * @return void
      */
     public function offsetUnset($offset)
     {

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -61,9 +61,10 @@ class Sdk
     /**
      * Client configuration data
      *
-     * @var array
+     * @var array{'base_uri': array<String, String>, 'timeout': ?float, 'handler': ?callable}
      */
     private $config = [
+        'base_uri' => [],
         'timeout' => 2.0,
         'handler' => null
     ];
@@ -85,7 +86,7 @@ class Sdk
      *
      * @link http://guzzle.readthedocs.io/en/latest/quickstart.html Guzzle documentation
      *
-     * @param array     $args           Client configuration arguments
+     * @param array<String, mixed> $args Client configuration arguments
      * @param string    $appId          Client application ID
      * @param string    $appPassword    Client application password
      *
@@ -94,7 +95,7 @@ class Sdk
      * @throws InvalidArgumentException If any required options are missing or
      *                                   an invalid value is provided.
      */
-    public function __construct(array $args, string $appId = '', string $appPassword = '')
+    final public function __construct(array $args, string $appId = '', string $appPassword = '')
     {
         $this->appId = $appId;
         $this->appPassword = $appPassword;
@@ -200,7 +201,7 @@ class Sdk
             }
         }
 
-        if (!isset($this->config[self::BASE_URI])) {
+        if (count($this->config[self::BASE_URI]) === 0) {
             throw new InvalidArgumentException(
                 'You must specify one of either the `env` or `base_uri` config ' .
                 'option values.',
@@ -224,7 +225,7 @@ class Sdk
      *
      * @return self
      */
-    public static function create(
+    final public static function create(
         HostName $hostName,
         string $appId,
         string $appPassword,
@@ -310,6 +311,12 @@ class Sdk
         return $this->createClient('Serato\\SwsSdk\\Notifications\\NotificationsClient');
     }
 
+    /**
+     * Creates a Client
+     *
+     * @param string $className
+     * @return mixed
+     */
     private function createClient(string $className)
     {
         return new $className($this->config, $this->appId, $this->appPassword);
@@ -318,7 +325,7 @@ class Sdk
     /**
      * Return the current configuration options
      *
-     * @return array
+     * @return array<String, mixed>
      */
     public function getConfig(): array
     {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -18,10 +18,10 @@ abstract class AbstractTestCase extends TestCase
      * Constructs a test case with the given name.
      *
      * @param string $name
-     * @param array  $data
+     * @param array<mixed>  $data
      * @param string $dataName
      */
-    public function __construct($name = null, array $data = array(), $dataName = '')
+    public function __construct($name = null, array $data = [], $dataName = '')
     {
         parent::__construct($name, $data, $dataName);
         // Error reporting as defined in php.ini file

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -21,14 +21,14 @@ class ClientTest extends AbstractTestCase
     const BEARER_TOKEN_AUTH_COMMAND_NAME  = 'GetUser';
     const BEARER_TOKEN_AUTH_COMMAND_CLASS = '\\Serato\\SwsSdk\\Identity\\Command\\UserGet';
 
-    public function testGetValidBasicAuthCommand()
+    public function testGetValidBasicAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $command = $clientMock->getCommand(self::BASIC_AUTH_COMMAND_NAME, $this->getCommandArgs());
         $this->assertTrue(is_a($command, self::BASIC_AUTH_COMMAND_CLASS));
     }
 
-    public function testGetValidBearerTokenAuthCommand()
+    public function testGetValidBearerTokenAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $command = $clientMock->getCommand(self::BEARER_TOKEN_AUTH_COMMAND_NAME);
@@ -38,13 +38,13 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testGetInvalidCommand()
+    public function testGetInvalidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $clientMock->getCommand('NoSuchCommand', $this->getCommandArgs());
     }
 
-    public function testExecuteValidBasicAuthCommand()
+    public function testExecuteValidBasicAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $result = $clientMock->execute(self::BASIC_AUTH_COMMAND_NAME, $this->getCommandArgs());
@@ -58,7 +58,7 @@ class ClientTest extends AbstractTestCase
         );
     }
 
-    public function testExecuteValidBearerTokenAuthCommand()
+    public function testExecuteValidBearerTokenAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $result = $clientMock->execute(self::BEARER_TOKEN_AUTH_COMMAND_NAME);
@@ -75,13 +75,13 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExecuteInvalidCommand()
+    public function testExecuteInvalidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $clientMock->execute('NoSuchCommand', $this->getCommandArgs());
     }
 
-    public function testExecuteAsyncValidCommand()
+    public function testExecuteAsyncValidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $promise = $clientMock->executeAsync(self::BASIC_AUTH_COMMAND_NAME, $this->getCommandArgs());
@@ -99,13 +99,13 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExecuteAsyncInvalidCommand()
+    public function testExecuteAsyncInvalidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $clientMock->executeAsync('NoSuchCommand', $this->getCommandArgs());
     }
 
-    public function testExecuteMagicMethodValidBasicAuthCommand()
+    public function testExecuteMagicMethodValidBasicAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $result = $clientMock->getUser('my_bearer_token');
@@ -119,7 +119,7 @@ class ClientTest extends AbstractTestCase
         );
     }
 
-    public function testExecuteMagicMethodValidBearerTokenAuthCommand()
+    public function testExecuteMagicMethodValidBearerTokenAuthCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $result = $clientMock->getUser();
@@ -136,13 +136,13 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExecuteMagicMethodInvalidCommand()
+    public function testExecuteMagicMethodInvalidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $clientMock->noSuchMethod($this->getCommandArgs());
     }
 
-    public function testExecuteAsyncMagicMethodValidCommand()
+    public function testExecuteAsyncMagicMethodValidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $promise = $clientMock->getProductAsync($this->getCommandArgs());
@@ -160,7 +160,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testExecuteAsyncMagicMethodInvalidCommand()
+    public function testExecuteAsyncMagicMethodInvalidCommand(): void
     {
         $clientMock = $this->getMockClient([$this->getMock200Response()]);
         $clientMock->noSuchMethodAsync($this->getCommandArgs());
@@ -169,7 +169,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \Serato\SwsSdk\Exception\BadRequestException
      */
-    public function test400ClientError()
+    public function test400ClientError(): void
     {
         $response = new Response(
             400,
@@ -183,7 +183,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \Serato\SwsSdk\Exception\AccessDeniedException
      */
-    public function test403Response()
+    public function test403Response(): void
     {
         $response = new Response(
             403,
@@ -198,7 +198,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \Serato\SwsSdk\Exception\ResourceNotFoundException
      */
-    public function test404Response()
+    public function test404Response(): void
     {
         $response = new Response(
             404,
@@ -213,7 +213,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \Serato\SwsSdk\Exception\ServerApplicationErrorException
      */
-    public function test500Response()
+    public function test500Response(): void
     {
         $response = new Response(
             500,
@@ -228,7 +228,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException \Serato\SwsSdk\Exception\ServiceUnavailableException
      */
-    public function test503Response()
+    public function test503Response(): void
     {
         $response = new Response(
             503,
@@ -243,7 +243,7 @@ class ClientTest extends AbstractTestCase
     /**
      * @expectedException GuzzleHttp\Exception\ConnectException
      */
-    public function testRequestTimeout()
+    public function testRequestTimeout(): void
     {
         $exception = new ConnectException(
             "Error Communicating with Server",
@@ -254,7 +254,7 @@ class ClientTest extends AbstractTestCase
         $clientMock->getProduct($this->getCommandArgs());
     }
 
-    protected function getMock200Response()
+    protected function getMock200Response(): Response
     {
         return new Response(
             200,
@@ -263,11 +263,20 @@ class ClientTest extends AbstractTestCase
         );
     }
 
-    protected function getCommandArgs()
+    /**
+     * @return array{'product_id': String}
+     */
+    protected function getCommandArgs(): array
     {
         return ['product_id' => '100-100'];
     }
 
+    /**
+     * Undocumented function
+     *
+     * @param array<mixed> $mockResponses
+     * @return mixed
+     */
     protected function getMockClient(array $mockResponses)
     {
         $args = [

--- a/tests/CommandBasicAuthTest.php
+++ b/tests/CommandBasicAuthTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\CommandBasicAuth;
 
 class CommandBasicAuthTest extends AbstractTestCase
 {
-    /* @var CommandBasicAuth */
+    /** @var mixed */
     private $commandMock;
 
     public function testCommandHeaders(): void
@@ -31,9 +31,9 @@ class CommandBasicAuthTest extends AbstractTestCase
     }
 
     /**
-     * @return CommandBasicAuth
+     * @return void
      */
-    private function createCommandBasicAuthMock()
+    private function createCommandBasicAuthMock(): void
     {
         $this->commandMock = $this->getMockForAbstractClass(
             CommandBasicAuth::class,

--- a/tests/CommandBasicAuthTest.php
+++ b/tests/CommandBasicAuthTest.php
@@ -11,7 +11,7 @@ class CommandBasicAuthTest extends AbstractTestCase
     /* @var CommandBasicAuth */
     private $commandMock;
 
-    public function testCommandHeaders()
+    public function testCommandHeaders(): void
     {
         $this->createCommandBasicAuthMock();
 

--- a/tests/CommandBearerTokenAuthTest.php
+++ b/tests/CommandBearerTokenAuthTest.php
@@ -11,7 +11,7 @@ class CommandBearerTokenAuthTest extends AbstractTestCase
     /* @var CommandBearerTokenAuth */
     private $commandMock;
 
-    public function testCommandHeaders()
+    public function testCommandHeaders(): void
     {
         $this->createCommandBasicAuthMock();
 

--- a/tests/CommandBearerTokenAuthTest.php
+++ b/tests/CommandBearerTokenAuthTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\CommandBearerTokenAuth;
 
 class CommandBearerTokenAuthTest extends AbstractTestCase
 {
-    /* @var CommandBearerTokenAuth */
+    /** @var mixed */
     private $commandMock;
 
     public function testCommandHeaders(): void
@@ -32,9 +32,9 @@ class CommandBearerTokenAuthTest extends AbstractTestCase
     }
 
     /**
-     * @return CommandBearerTokenAuth
+     * @return void
      */
-    private function createCommandBasicAuthMock()
+    private function createCommandBasicAuthMock(): void
     {
         $this->commandMock = $this->getMockForAbstractClass(
             CommandBearerTokenAuth::class,

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -11,7 +11,7 @@ use DateTime;
 
 class CommandTest extends AbstractTestCase
 {
-    /* @var Command */
+    /** @var mixed */
     private $commandMock;
 
     /**
@@ -45,7 +45,10 @@ class CommandTest extends AbstractTestCase
         $this->assertEquals('', (string)$request->getBody());
     }
 
-    public function commandConstructRequestProvider()
+    /**
+     * @return array<array<String>>
+     */
+    public function commandConstructRequestProvider(): array
     {
         return [
             ['GET', 'http', 'my.getserver.com', '/my/get/path'],
@@ -55,6 +58,14 @@ class CommandTest extends AbstractTestCase
     }
 
     /**
+     * Undocumented function
+     *
+     * @param array<mixed> $commandArgDef
+     * @param array<mixed> $commandArgs
+     * @param array<String> $exceptionTexts
+     * @param string $assertText
+     * @return void
+     *
      * @dataProvider commandArgsValidationProvider
      */
     public function testCommandArgsValidation(
@@ -109,6 +120,9 @@ class CommandTest extends AbstractTestCase
         $this->assertRegExp(FirewallHeader::HEADER_PATTERN, $firewallHeader);
     }
 
+    /**
+     * @return array<array<mixed>>>
+     */
     public function commandArgsValidationProvider(): array
     {
         $commandArgDef = [
@@ -196,6 +210,12 @@ class CommandTest extends AbstractTestCase
         ];
     }
 
+    /**
+     * @param string $httpScheme
+     * @param string $httpHost
+     * @param array<mixed> $commandArgs
+     * @return void
+     */
     private function createCommandMock(string $httpScheme, string $httpHost, array $commandArgs = []): void
     {
         $this->commandMock = $this->getMockForAbstractClass(

--- a/tests/Da/DaClientTest.php
+++ b/tests/Da/DaClientTest.php
@@ -11,7 +11,7 @@ class DaClientTest extends AbstractTestCase
 {
     const DA_SERVER_BASE_URI = 'http://da.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new DaClient(
             [

--- a/tests/Ecom/Command/InvoiceCreateTest.php
+++ b/tests/Ecom/Command/InvoiceCreateTest.php
@@ -5,10 +5,14 @@ namespace Serato\SwsSdk\Test\Ecom\Command;
 
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Ecom\Command\InvoiceCreate;
+use DateTime;
 
 class InvoiceCreateTest extends AbstractTestCase
 {
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             [[]],
@@ -18,8 +22,10 @@ class InvoiceCreateTest extends AbstractTestCase
 
     /**
      * Tests that an exception is thrown if required parameters are missing.
-     * @dataProvider missingRequiredArgProvider
      *
+     * @param array<string, DateTime|int|string> $args
+     *
+     * @dataProvider missingRequiredArgProvider
      * @expectedException \InvalidArgumentException
      */
     public function testMissingRequiredArg(array $args): void

--- a/tests/Ecom/Command/SubscriptionCancelTest.php
+++ b/tests/Ecom/Command/SubscriptionCancelTest.php
@@ -5,13 +5,16 @@ namespace Serato\SwsSdk\Test\Ecom\Command;
 
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Ecom\Command\SubscriptionCancel;
+use DateTime;
 
 class SubscriptionCancelTest extends AbstractTestCase
 {
     /**
      * Data provider
+     *
+     * @return array<array>
      */
-    public function missingRequiredArgProvider()
+    public function missingRequiredArgProvider(): array
     {
         return [
             [[]],
@@ -21,11 +24,12 @@ class SubscriptionCancelTest extends AbstractTestCase
     }
 
     /**
-     * @dataProvider missingRequiredArgProvider
+     * @param array<string, DateTime|int|string> $args
      *
+     * @dataProvider missingRequiredArgProvider
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new SubscriptionCancel(
             'app_id',
@@ -36,7 +40,7 @@ class SubscriptionCancelTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $subId = 'sub-123';
         $userId = 123;

--- a/tests/Ecom/Command/SubscriptionListTest.php
+++ b/tests/Ecom/Command/SubscriptionListTest.php
@@ -9,7 +9,7 @@ use Serato\SwsSdk\Ecom\Command\SubscriptionList;
 class SubscriptionListTest extends AbstractTestCase
 {
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
         $command = new SubscriptionList(

--- a/tests/Ecom/EcomClientTest.php
+++ b/tests/Ecom/EcomClientTest.php
@@ -11,7 +11,7 @@ class EcomClientTest extends AbstractTestCase
 {
     const ECOM_SERVER_BASE_URI = 'http://ecom.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new EcomClient(
             [
@@ -32,7 +32,7 @@ class EcomClientTest extends AbstractTestCase
     }
 
     /* Testing magic methods (smoke test) */
-    public function testSubscriptionList()
+    public function testSubscriptionList(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createEcomClient();
@@ -43,7 +43,7 @@ class EcomClientTest extends AbstractTestCase
         );
     }
 
-    public function testCancelSubscription()
+    public function testCancelSubscription(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createEcomClient();

--- a/tests/Exception/ErrorCodeResponseExceptionTest.php
+++ b/tests/Exception/ErrorCodeResponseExceptionTest.php
@@ -10,7 +10,7 @@ use Exception;
 
 class ErrorCodeResponseExceptionTest extends AbstractTestCase
 {
-    /* @var ErrorMessageResponseException */
+    /** @var mixed */
     private $mockException;
 
     public function testConstructor(): void
@@ -43,9 +43,9 @@ class ErrorCodeResponseExceptionTest extends AbstractTestCase
     }
 
     /**
-     * @return ErrorCodeResponseException
+     * @param Exception $e
      */
-    private function createMockException($e)
+    private function createMockException($e): void
     {
         $this->mockException = $this->getMockForAbstractClass(ErrorCodeResponseException::class, [$e]);
     }

--- a/tests/Exception/ErrorCodeResponseExceptionTest.php
+++ b/tests/Exception/ErrorCodeResponseExceptionTest.php
@@ -13,7 +13,7 @@ class ErrorCodeResponseExceptionTest extends AbstractTestCase
     /* @var ErrorMessageResponseException */
     private $mockException;
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $code = 1004;
         $message = 'A meaningful error message';

--- a/tests/Exception/ErrorMessageResponseExceptionTest.php
+++ b/tests/Exception/ErrorMessageResponseExceptionTest.php
@@ -10,7 +10,7 @@ use Exception;
 
 class ErrorMessageResponseExceptionTest extends AbstractTestCase
 {
-    /* @var ErrorMessageResponseException */
+    /** @var mixed */
     private $mockException;
 
     public function testConstructor(): void
@@ -43,9 +43,10 @@ class ErrorMessageResponseExceptionTest extends AbstractTestCase
     }
 
     /**
-     * @return ErrorMessageResponseException
+     * @param Exception $e
+     * @return void
      */
-    private function createMockException($e)
+    private function createMockException($e): void
     {
         $this->mockException = $this->getMockForAbstractClass(ErrorMessageResponseException::class, [$e]);
     }

--- a/tests/Exception/ErrorMessageResponseExceptionTest.php
+++ b/tests/Exception/ErrorMessageResponseExceptionTest.php
@@ -13,7 +13,7 @@ class ErrorMessageResponseExceptionTest extends AbstractTestCase
     /* @var ErrorMessageResponseException */
     private $mockException;
 
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $httpResponseCode = 500;
         $message = 'A meaningful error message';

--- a/tests/Identity/Command/TokenExchangeTest.php
+++ b/tests/Identity/Command/TokenExchangeTest.php
@@ -10,6 +10,9 @@ use GuzzleHttp\Psr7\Uri;
 class TokenExchangeTest extends AbstractTestCase
 {
     /**
+     * @param array<mixed> $args
+     * @return void
+     *
      * @dataProvider missingRequiredArgProvider
      *
      * @expectedException \InvalidArgumentException
@@ -26,7 +29,10 @@ class TokenExchangeTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             [[]],

--- a/tests/Identity/Command/TokenExchangeTest.php
+++ b/tests/Identity/Command/TokenExchangeTest.php
@@ -14,7 +14,7 @@ class TokenExchangeTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new TokenExchange(
             'app_id',
@@ -36,7 +36,7 @@ class TokenExchangeTest extends AbstractTestCase
         ];
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $grantType      = 'my_grant_type';
         $code           = '123abc456';

--- a/tests/Identity/Command/UserAddGaClientIdTest.php
+++ b/tests/Identity/Command/UserAddGaClientIdTest.php
@@ -9,6 +9,9 @@ use Serato\SwsSdk\Identity\Command\UserAddGaClientId;
 class UserAddGaClientIdTest extends AbstractTestCase
 {
     /**
+     * @param array<mixed> $args
+     * @return void
+     *
      * @dataProvider missingRequiredArgProvider
      *
      * @expectedException \InvalidArgumentException
@@ -25,7 +28,10 @@ class UserAddGaClientIdTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             [[]],

--- a/tests/Identity/Command/UserAddGaClientIdTest.php
+++ b/tests/Identity/Command/UserAddGaClientIdTest.php
@@ -13,7 +13,7 @@ class UserAddGaClientIdTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new UserAddGaClientId(
             'app_id',
@@ -34,7 +34,7 @@ class UserAddGaClientIdTest extends AbstractTestCase
         ];
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
         $gaClientId = '123abc456';

--- a/tests/Identity/Command/UserGetTest.php
+++ b/tests/Identity/Command/UserGetTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\Identity\Command\UserGet;
 
 class UserGetTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $command = new UserGet(
             'app_id',

--- a/tests/Identity/Command/UserGroupAddTest.php
+++ b/tests/Identity/Command/UserGroupAddTest.php
@@ -8,7 +8,10 @@ use Serato\SwsSdk\Identity\Command\UserGroupAdd;
 
 class UserGroupAddTest extends AbstractTestCase
 {
-     /**
+    /**
+     * @param array<mixed> $args
+     * @return void
+     *
      * @dataProvider missingRequiredArgProvider
      *
      * @expectedException \InvalidArgumentException
@@ -25,7 +28,10 @@ class UserGroupAddTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             ['group_name' => ["root"]]

--- a/tests/Identity/Command/UserGroupAddTest.php
+++ b/tests/Identity/Command/UserGroupAddTest.php
@@ -13,7 +13,7 @@ class UserGroupAddTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new UserGroupAdd(
             'app_id',
@@ -32,21 +32,7 @@ class UserGroupAddTest extends AbstractTestCase
         ];
     }
 
-    /**
-     * Test that missing user id
-     * @expectedException \InvalidArgumentException
-     */
-    public function missingUserId()
-    {
-        $command = new UserGroupAdd(
-            'app_id',
-            'app_password',
-            'http://my.server.com',
-            ['group_name' => "root"]
-        );
-    }
-
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
         $groupName = "root";

--- a/tests/Identity/Command/UserGroupRemoveTest.php
+++ b/tests/Identity/Command/UserGroupRemoveTest.php
@@ -11,7 +11,7 @@ class UserGroupRemoveTest extends AbstractTestCase
      /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new UserGroupRemove(
             'app_id',
@@ -23,21 +23,7 @@ class UserGroupRemoveTest extends AbstractTestCase
         $command->getRequest();
     }
 
-     /**
-     * Test that missing user id
-     * @expectedException \InvalidArgumentException
-     */
-    public function missingUserId()
-    {
-        $command = new UserGroupRemove(
-            'app_id',
-            'app_password',
-            'http://my.server.com',
-            ['group_name' => "root"]
-        );
-    }
-
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 1234;
         $groupName = "root";

--- a/tests/Identity/Command/UserListTest.php
+++ b/tests/Identity/Command/UserListTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\Identity\Command\UserList;
 
 class UserListTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $emailAddress   = 'emailadress';
         $gaClientId     = '123abc456def';

--- a/tests/Identity/IdentityClientTest.php
+++ b/tests/Identity/IdentityClientTest.php
@@ -11,7 +11,7 @@ class IdentityClientTest extends AbstractTestCase
 {
     const ID_SERVER_BASE_URI = 'http://id.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new IdentityClient(
             [
@@ -33,7 +33,7 @@ class IdentityClientTest extends AbstractTestCase
 
     /* The remaining tests are smoke tests for each magic method provided by the client */
 
-    public function testGetUser()
+    public function testGetUser(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -44,7 +44,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testGetUsers()
+    public function testGetUsers(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -55,7 +55,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testUserAddGaClientId()
+    public function testUserAddGaClientId(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -66,7 +66,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testTokenExchange()
+    public function testTokenExchange(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -77,7 +77,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testTokenRefresh()
+    public function testTokenRefresh(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -88,7 +88,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testUserGroupAdd()
+    public function testUserGroupAdd(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();
@@ -100,7 +100,7 @@ class IdentityClientTest extends AbstractTestCase
         );
     }
 
-    public function testUserGroupRemove()
+    public function testUserGroupRemove(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createIdentityClient();

--- a/tests/License/Command/LicenseListTest.php
+++ b/tests/License/Command/LicenseListTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\License\Command\LicenseList;
 
 class LicenseListTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
 

--- a/tests/License/Command/ProductCreateTest.php
+++ b/tests/License/Command/ProductCreateTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\License\Command\ProductCreate;
 
 class ProductCreateTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $command = new ProductCreate(
             'app_id',
@@ -33,7 +33,7 @@ class ProductCreateTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new ProductCreate(
             'app_id',

--- a/tests/License/Command/ProductDeleteTest.php
+++ b/tests/License/Command/ProductDeleteTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\License\Command\ProductDelete;
 
 class ProductDeleteTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $productId = '100-100';
 
@@ -29,7 +29,7 @@ class ProductDeleteTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new ProductDelete(
             'app_id',

--- a/tests/License/Command/ProductGetTest.php
+++ b/tests/License/Command/ProductGetTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\License\Command\ProductGet;
 
 class ProductGetTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $productId = '100-100';
 
@@ -28,7 +28,7 @@ class ProductGetTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new ProductGet(
             'app_id',

--- a/tests/License/Command/ProductListTest.php
+++ b/tests/License/Command/ProductListTest.php
@@ -8,7 +8,7 @@ use Serato\SwsSdk\License\Command\ProductList;
 
 class ProductListTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $orderId = 100000;
 

--- a/tests/License/Command/ProductUpdateTest.php
+++ b/tests/License/Command/ProductUpdateTest.php
@@ -9,7 +9,7 @@ use DateTime;
 
 class ProductUpdateTest extends AbstractTestCase
 {
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $productId = '100-100';
         $dateTime = DateTime::createFromFormat('Y-m-d H:i:s', '2017-02-01 23:30:30');
@@ -41,7 +41,7 @@ class ProductUpdateTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new ProductUpdate(
             'app_id',

--- a/tests/License/Command/ProductUpdateTest.php
+++ b/tests/License/Command/ProductUpdateTest.php
@@ -6,13 +6,14 @@ namespace Serato\SwsSdk\Test\License\Command;
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\License\Command\ProductUpdate;
 use DateTime;
+use Exception;
 
 class ProductUpdateTest extends AbstractTestCase
 {
     public function testSmokeTest(): void
     {
         $productId = '100-100';
-        $dateTime = DateTime::createFromFormat('Y-m-d H:i:s', '2017-02-01 23:30:30');
+        $dateTime = new DateTime;
 
         $command = new ProductUpdate(
             'app_id',
@@ -31,10 +32,8 @@ class ProductUpdateTest extends AbstractTestCase
         $this->assertRegExp('/^\/api\/v1\/products\/products\/' . $productId . '$/', $request->getUri()->getPath());
         $this->assertRegExp('/^Basic [[:alnum:]=]+$/', $request->getHeaderLine('Authorization'));
         $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
-        if ($dateTime) {
-            $dateString = $dateTime->format(DateTime::RFC3339);
-            $this->assertEquals($dateString, $bodyParams['valid_to']);
-        }
+        $dateString = $dateTime->format(DateTime::RFC3339);
+        $this->assertEquals($dateString, $bodyParams['valid_to']);
         $this->assertEquals('Past Due', $bodyParams['subscription_status']);
     }
 

--- a/tests/License/LicenseClientTest.php
+++ b/tests/License/LicenseClientTest.php
@@ -11,7 +11,7 @@ class LicenseClientTest extends AbstractTestCase
 {
     const LICENSE_SERVER_BASE_URI = 'http://license.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new LicenseClient(
             [
@@ -33,7 +33,7 @@ class LicenseClientTest extends AbstractTestCase
 
     /* The remaining tests are smoke tests for each magic method provided by the client */
 
-    public function testGetProducts()
+    public function testGetProducts(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createLicenseClient();
@@ -44,7 +44,7 @@ class LicenseClientTest extends AbstractTestCase
         );
     }
 
-    public function testGetProduct()
+    public function testGetProduct(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createLicenseClient();
@@ -55,7 +55,7 @@ class LicenseClientTest extends AbstractTestCase
         );
     }
 
-    public function testCreateProduct()
+    public function testCreateProduct(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createLicenseClient();
@@ -66,7 +66,7 @@ class LicenseClientTest extends AbstractTestCase
         );
     }
 
-    public function testUpdateProduct()
+    public function testUpdateProduct(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createLicenseClient();
@@ -77,7 +77,7 @@ class LicenseClientTest extends AbstractTestCase
         );
     }
 
-    public function testDeleteProduct()
+    public function testDeleteProduct(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createLicenseClient();

--- a/tests/Notifications/NotificationsClientTest.php
+++ b/tests/Notifications/NotificationsClientTest.php
@@ -11,7 +11,7 @@ class NotificationsClientTest extends AbstractTestCase
 {
     const NOTIFICATIONS_SERVER_BASE_URI = 'http://da.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new DaClient(
             [

--- a/tests/Profile/Command/PartnerPromotionAddUserTest.php
+++ b/tests/Profile/Command/PartnerPromotionAddUserTest.php
@@ -10,6 +10,9 @@ use Serato\SwsSdk\Profile\Command\PartnerPromotionAddUser;
 class PartnerPromotionAddUserTest extends AbstractTestCase
 {
     /**
+     * @param array<mixed> $args
+     * @return void
+     *
      * @dataProvider missingRequiredArgProvider
      *
      * @expectedException \InvalidArgumentException
@@ -26,7 +29,10 @@ class PartnerPromotionAddUserTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array<mixed>>>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             [['user_id' => 1234]],

--- a/tests/Profile/Command/PartnerPromotionAddUserTest.php
+++ b/tests/Profile/Command/PartnerPromotionAddUserTest.php
@@ -14,7 +14,7 @@ class PartnerPromotionAddUserTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new PartnerPromotionAddUser(
             'app_id',
@@ -33,7 +33,7 @@ class PartnerPromotionAddUserTest extends AbstractTestCase
             [['promotion_name' => 'test-promo-name']]
         ];
     }
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
 

--- a/tests/Profile/Command/UserAddBetaProgramTest.php
+++ b/tests/Profile/Command/UserAddBetaProgramTest.php
@@ -15,7 +15,7 @@ class UserAddBetaProgramTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new UserAddBetaProgram(
             'app_id',
@@ -34,7 +34,7 @@ class UserAddBetaProgramTest extends AbstractTestCase
         ];
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
         $betaProgramId = "serato_studio_beta";

--- a/tests/Profile/Command/UserAddBetaProgramTest.php
+++ b/tests/Profile/Command/UserAddBetaProgramTest.php
@@ -11,6 +11,9 @@ class UserAddBetaProgramTest extends AbstractTestCase
 {
 
     /**
+     * @param array<mixed> $args
+     * @return void
+     *
      * @dataProvider missingRequiredArgProvider
      *
      * @expectedException \InvalidArgumentException
@@ -27,7 +30,10 @@ class UserAddBetaProgramTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             ['beta_program_id' => ["beta_program_id"]]

--- a/tests/Profile/Command/UserGetBetaProgramTest.php
+++ b/tests/Profile/Command/UserGetBetaProgramTest.php
@@ -14,7 +14,7 @@ class UserGetBetaProgramTest extends AbstractTestCase
      *
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg(array $args)
+    public function testMissingRequiredArg(array $args): void
     {
         $command = new UserGetBetaProgram(
             'app_id',
@@ -32,7 +32,8 @@ class UserGetBetaProgramTest extends AbstractTestCase
             ['user_id' => [1234]]
         ];
     }
-    public function testSmokeTest()
+
+    public function testSmokeTest(): void
     {
         $userId = 123;
 

--- a/tests/Profile/Command/UserGetBetaProgramTest.php
+++ b/tests/Profile/Command/UserGetBetaProgramTest.php
@@ -10,8 +10,10 @@ use Serato\SwsSdk\Profile\Command\UserGetBetaProgram;
 class UserGetBetaProgramTest extends AbstractTestCase
 {
     /**
-     * @dataProvider missingRequiredArgProvider
+     * @param array<mixed> $args
+     * @return void
      *
+     * @dataProvider missingRequiredArgProvider
      * @expectedException \InvalidArgumentException
      */
     public function testMissingRequiredArg(array $args): void
@@ -26,7 +28,10 @@ class UserGetBetaProgramTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function missingRequiredArgProvider()
+    /**
+     * @return array<array{'user_id': array<Integer>}>
+     */
+    public function missingRequiredArgProvider(): array
     {
         return [
             ['user_id' => [1234]]

--- a/tests/Profile/Command/UserGetTest.php
+++ b/tests/Profile/Command/UserGetTest.php
@@ -11,7 +11,7 @@ class UserGetTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new UserGet(
             'app_id',
@@ -23,7 +23,7 @@ class UserGetTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $user_id = 123;
 

--- a/tests/Profile/Command/UserUpdateTest.php
+++ b/tests/Profile/Command/UserUpdateTest.php
@@ -12,7 +12,7 @@ class UserUpdateTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new UserUpdate(
             'app_id',
@@ -24,7 +24,7 @@ class UserUpdateTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $userId = 123;
 

--- a/tests/Profile/Command/UserValidateAllBetaProgramsTest.php
+++ b/tests/Profile/Command/UserValidateAllBetaProgramsTest.php
@@ -11,7 +11,7 @@ class UserValidateAllBetaProgramsTest extends AbstractTestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMissingRequiredArg()
+    public function testMissingRequiredArg(): void
     {
         $command = new UserValidateAllBetaPrograms(
             'app_id',
@@ -23,7 +23,7 @@ class UserValidateAllBetaProgramsTest extends AbstractTestCase
         $command->getRequest();
     }
 
-    public function testSmokeTest()
+    public function testSmokeTest(): void
     {
         $user_id = 123;
 

--- a/tests/Profile/ProfileClientTest.php
+++ b/tests/Profile/ProfileClientTest.php
@@ -11,7 +11,7 @@ class ProfileClientTest extends AbstractTestCase
 {
     const PROFILE_SERVER_BASE_URI = 'http://profile.server.com';
 
-    public function testGetBaseUri()
+    public function testGetBaseUri(): void
     {
         $client = new ProfileClient(
             [
@@ -33,7 +33,7 @@ class ProfileClientTest extends AbstractTestCase
 
     /* The remaining tests are smoke tests for each magic method provided by the client */
 
-    public function testGetUser()
+    public function testGetUser(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();
@@ -44,7 +44,7 @@ class ProfileClientTest extends AbstractTestCase
         );
     }
 
-    public function testUpdateUser()
+    public function testUpdateUser(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();
@@ -55,7 +55,7 @@ class ProfileClientTest extends AbstractTestCase
         );
     }
 
-    public function testGetUserBetaProgram()
+    public function testGetUserBetaProgram(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();
@@ -66,7 +66,7 @@ class ProfileClientTest extends AbstractTestCase
         );
     }
 
-    public function testAddUserBetaProgram()
+    public function testAddUserBetaProgram(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();
@@ -77,7 +77,7 @@ class ProfileClientTest extends AbstractTestCase
         );
     }
 
-    public function testValidateAllUserBetaPrograms()
+    public function testValidateAllUserBetaPrograms(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();
@@ -88,7 +88,7 @@ class ProfileClientTest extends AbstractTestCase
         );
     }
 
-    public function testPartnerPromotionAddUser()
+    public function testPartnerPromotionAddUser(): void
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createProfileClient();

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -13,7 +13,7 @@ class ResultTest extends AbstractTestCase
     /**
      * @dataProvider validJsonResultConstructorProvider
      */
-    public function testValidJsonResultConstructor($httpStatusCode, $body)
+    public function testValidJsonResultConstructor($httpStatusCode, $body): void
     {
         $jsonBody = json_encode($body);
         if ($jsonBody === false) {
@@ -46,7 +46,7 @@ class ResultTest extends AbstractTestCase
         ];
     }
 
-    public function testInvalidJsonResultConstructor()
+    public function testInvalidJsonResultConstructor(): void
     {
         $response = new Response(
             200,
@@ -65,7 +65,7 @@ class ResultTest extends AbstractTestCase
      *
      * @dataProvider get204ResponseProvider
      */
-    public function test204Responses($response)
+    public function test204Responses($response): void
     {
         $result = new Result($response);
 
@@ -97,7 +97,7 @@ class ResultTest extends AbstractTestCase
     /**
      * @expectedException \Exception
      */
-    public function testInvalidContentType()
+    public function testInvalidContentType(): void
     {
         $response = new Response(
             200,

--- a/tests/ResultTest.php
+++ b/tests/ResultTest.php
@@ -5,12 +5,17 @@ namespace Serato\SwsSdk\Test;
 
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Result;
+use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Psr7\Response;
 use Exception;
 
 class ResultTest extends AbstractTestCase
 {
     /**
+     * @param string $httpStatusCode
+     * @param array<mixed> $body
+     * @return void
+     *
      * @dataProvider validJsonResultConstructorProvider
      */
     public function testValidJsonResultConstructor($httpStatusCode, $body): void
@@ -36,7 +41,10 @@ class ResultTest extends AbstractTestCase
         }
     }
 
-    public function validJsonResultConstructorProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function validJsonResultConstructorProvider(): array
     {
         $data = ['var1' => 'val1', 'var2' => 2, 'var3' => 'val3'];
         return [
@@ -63,9 +71,12 @@ class ResultTest extends AbstractTestCase
     /**
      * 204 responses are not required to send a `Content-Type': application/json` header
      *
+     * @param ResponseInterface $response
+     * @return void
+     *
      * @dataProvider get204ResponseProvider
      */
-    public function test204Responses($response): void
+    public function test204Responses(ResponseInterface $response): void
     {
         $result = new Result($response);
 
@@ -73,7 +84,10 @@ class ResultTest extends AbstractTestCase
         $this->assertEquals(0, count($result));
     }
 
-    public function get204ResponseProvider()
+    /**
+     * @return array<array<ResponseInterface>>
+     */
+    public function get204ResponseProvider(): array
     {
         return [
             [new Response(204, [])],

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -6,6 +6,7 @@ namespace Serato\SwsSdk\Test;
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Sdk;
 use InvalidArgumentException;
+use Serato\ServiceDiscovery\HostName;
 
 class SdkTest extends AbstractTestCase
 {
@@ -28,10 +29,6 @@ class SdkTest extends AbstractTestCase
             [['timeout' => 2], 1000, 'Non-float value for `timeout`'],
             [['timeout' => 2.0, 'env' => 'invalid'], 1001, 'Invalid `env` value'],
             [['base_uri' => ''], 1002, 'Non-array `base_uri` value'],
-            [['base_uri' => ['id' => 'value']], 1002, 'Missing `base_uri` `license`, `profile` and `ecom` values'],
-            [['base_uri' => ['license' => 'value']], 1002, 'Missing `base_uri` `id`, `profile` and `ecom` values'],
-            [['base_uri' => ['profile' => 'value']], 1002, 'Missing `base_uri` `id`, `license` and `ecom` values'],
-            [['base_uri' => ['ecom' => 'value']], 1002, 'Missing `base_uri` `id`, `license` and `profile` values'],
             [
                 ['base_uri' => [
                         'id' => 'invalid value',
@@ -51,7 +48,7 @@ class SdkTest extends AbstractTestCase
                         'ecom' => 'http://my.server'
                    ]
                 ],
-                1004,
+                1003,
                 'Invalid `base_uri` `license` value'
             ],
             [
@@ -62,7 +59,7 @@ class SdkTest extends AbstractTestCase
                         'ecom' => 'http://my.server'
                     ]
                 ],
-                1007,
+                1003,
                 'Invalid `base_uri` `profile` value'
             ],
             [
@@ -73,7 +70,7 @@ class SdkTest extends AbstractTestCase
                         'ecom' => 'invalid value'
                     ]
                 ],
-                1008,
+                1003,
                 'Invalid `base_uri` `ecom` value'
             ],
             [
@@ -249,5 +246,32 @@ class SdkTest extends AbstractTestCase
                 'Set `env` to ENV_PRODUCTION, custom `handler`'
             ]
         ];
+    }
+
+    public function testCreateMethod(): void
+    {
+        $appId = 'my-app-id';
+        $appSecret = 'my-app-secret';
+        $timeout = 3.33;
+        $handler = function () {
+            echo 'this is a function';
+        };
+
+        $hostName = new HostName('production', 1);
+        $sdk = Sdk::create($hostName, $appId, $appSecret, $timeout, $handler);
+
+        $config = $sdk->getConfig();
+
+        $this->assertEquals($appId, $sdk->getAppId());
+        $this->assertEquals($appSecret, $sdk->getAppPassword());
+        $this->assertEquals($timeout, $config['timeout']);
+        $this->assertEquals($handler, $config['handler']);
+
+        $this->assertEquals($hostName->get(HostName::IDENTITY), $config['base_uri']['id']);
+        $this->assertEquals($hostName->get(HostName::LICENSE), $config['base_uri']['license']);
+        $this->assertEquals($hostName->get(HostName::PROFILE), $config['base_uri']['profile']);
+        $this->assertEquals($hostName->get(HostName::ECOM), $config['base_uri']['ecom']);
+        $this->assertEquals($hostName->get(HostName::DIGITAL_ASSETS), $config['base_uri']['da']);
+        $this->assertEquals($hostName->get(HostName::NOTIFICATIONS), $config['base_uri']['notifications']);
     }
 }

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -11,9 +11,14 @@ use Serato\ServiceDiscovery\HostName;
 class SdkTest extends AbstractTestCase
 {
     /**
+     * @param array<mixed> $args
+     * @param int $exceptionCode
+     * @param string $assertText
+     * @return void
+     *
      * @dataProvider invalidConstructorOptionsProvider
      */
-    public function testInvalidConstructorOptions(array $args, $exceptionCode, $assertText): void
+    public function testInvalidConstructorOptions(array $args, int $exceptionCode, string $assertText): void
     {
         try {
             $sdk = new Sdk($args, 'app_id', 'app_password');
@@ -22,7 +27,10 @@ class SdkTest extends AbstractTestCase
         }
     }
 
-    public function invalidConstructorOptionsProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function invalidConstructorOptionsProvider(): array
     {
         return [
             [[], 1005, 'No `env` or `base_uri` provided'],
@@ -82,19 +90,31 @@ class SdkTest extends AbstractTestCase
     }
 
     /**
+     * @param array<mixed> $args
+     * @param string  $idServiceUri
+     * @param string  $licenseServiceUri
+     * @param string  $profileServiceUri
+     * @param string  $ecomServiceUri
+     * @param string  $daServiceUri
+     * @param string  $notificationsServiceUri
+     * @param float $timeout|null
+     * @param callable $handler|null
+     * @param string $assertText
+     * @return void
+     *
      * @dataProvider validConstructorOptionsProvider
      */
     public function testValidConstructorOptions(
         array $args,
-        $idServiceUri,
-        $licenseServiceUri,
-        $profileServiceUri,
-        $ecomServiceUri,
-        $daServiceUri,
-        $notificationsServiceUri,
-        $timeout,
-        $handler,
-        $assertText
+        string $idServiceUri,
+        string $licenseServiceUri,
+        string $profileServiceUri,
+        string $ecomServiceUri,
+        string $daServiceUri,
+        string $notificationsServiceUri,
+        ?float $timeout = null,
+        ?callable $handler = null,
+        string $assertText
     ): void {
         $sdk = new Sdk($args, 'app_id', 'app_password');
         $config = $sdk->getConfig();
@@ -151,7 +171,10 @@ class SdkTest extends AbstractTestCase
         );
     }
 
-    public function validConstructorOptionsProvider()
+    /**
+     * @return array<array<mixed>>
+     */
+    public function validConstructorOptionsProvider(): array
     {
         $idServiceUri       = 'https://id.server.com';
         $licenseServiceUri  = 'https://license.server.io';

--- a/tests/SdkTest.php
+++ b/tests/SdkTest.php
@@ -13,7 +13,7 @@ class SdkTest extends AbstractTestCase
     /**
      * @dataProvider invalidConstructorOptionsProvider
      */
-    public function testInvalidConstructorOptions(array $args, $exceptionCode, $assertText)
+    public function testInvalidConstructorOptions(array $args, $exceptionCode, $assertText): void
     {
         try {
             $sdk = new Sdk($args, 'app_id', 'app_password');
@@ -95,7 +95,7 @@ class SdkTest extends AbstractTestCase
         $timeout,
         $handler,
         $assertText
-    ) {
+    ): void {
         $sdk = new Sdk($args, 'app_id', 'app_password');
         $config = $sdk->getConfig();
 


### PR DESCRIPTION
This is a BIG PR because I upgraded to phpstan 0.12. This necessitated a lot of fixes for the stricter analysis performed by the newer version.

The meaning change is in this [commit](https://github.com/serato/sws-php-sdk/commit/3cf2d0def4de69af2c8758c211074064b8a05a50).

The [other commits](https://github.com/serato/sws-php-sdk/compare/bootstrap-with-service-discovery) are exclusively fixing phpstan analysis bugs. In some cases a very small amount of code had to be rewritten, but the vast majority of the changes are phpdoc updates. Tests are passing but some manual testing should be done before merging the changes.

The meaning full change is a the new [_create_ static function](https://github.com/serato/sws-php-sdk/blob/bootstrap-with-service-discovery/src/Sdk.php#L228) to create a _Serato\SwsSdk\Sdk_ instance using a constructed _Serato\ServiceDiscovery\HostName_ instance.