### PR TITLE
[TDO-372] Add option to authenticate requests with CDN via custom header

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -47,6 +47,20 @@ abstract class Client extends GuzzleClient
     protected $config;
 
     /**
+     * Client identifier used to identify the application to test stack CDNs
+     *
+     * @var string
+     */
+    protected $cdnAuthId;
+
+    /**
+     * Secret used to authenticate requests to test stack CDNs.
+     *
+     * @var string
+     */
+    protected $cdnAuthSecret;
+
+    /**
      * The `$args` parameter is an array containing any value configuration for
      * a `GuzzleHttp\Client`. See the Guzzle docs for more info.
      *
@@ -55,16 +69,25 @@ abstract class Client extends GuzzleClient
      * @param array     $args           Client configuration arguments
      * @param string    $appId          Client application ID
      * @param string    $appPassword    Client application password
+     * @param string    $cdnAuthId      Client identifier used to identify the application to test stack CDNs
+     * @param string    $cdnAuthSecret  Secret used to authenticate requests to test stack CDNs
      *
      * @return void
      */
-    public function __construct(array $args, string $appId, string $appPassword)
-    {
-        $this->appId        = $appId;
-        $this->appPassword  = $appPassword;
-        $this->config       = $args;
+    public function __construct(
+        array $args,
+        string $appId,
+        string $appPassword,
+        string $cdnAuthId = '',
+        string $cdnAuthSecret = ''
+    ) {
+        $this->appId         = $appId;
+        $this->appPassword   = $appPassword;
+        $this->config        = $args;
+        $this->cdnAuthSecret = $cdnAuthSecret;
+        $this->cdnAuthId     = $cdnAuthId;
         unset($args[Sdk::BASE_URI]);
-        $argsNoBaseUri      = $args;
+        $argsNoBaseUri       = $args;
 
         parent::__construct($argsNoBaseUri);
     }
@@ -89,7 +112,9 @@ abstract class Client extends GuzzleClient
             $this->appId,
             $this->appPassword,
             $this->getBaseUri(),
-            $args
+            $args,
+            $this->cdnAuthId,
+            $this->cdnAuthSecret
         );
     }
 

--- a/src/CommandBasicAuth.php
+++ b/src/CommandBasicAuth.php
@@ -14,9 +14,15 @@ abstract class CommandBasicAuth extends Command
     /**
      * {@inheritdoc}
      */
-    public function __construct(string $appId, string $appPassword, string $baseUri, array $args)
-    {
-        parent::__construct($appId, $appPassword, $baseUri, $args);
+    public function __construct(
+        string $appId,
+        string $appPassword,
+        string $baseUri,
+        array $args,
+        string $cdnAuthId = '',
+        string $cdnAuthSecret = ''
+    ) {
+        parent::__construct($appId, $appPassword, $baseUri, $args, $cdnAuthId, $cdnAuthSecret);
         $this->setBasicAuthHeader();
     }
 

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -65,6 +65,20 @@ class Sdk
     private $appPassword;
 
     /**
+     * Client identifier used to identify the application to test stack CDNs via a custom header
+     *
+     * @var string
+     */
+    private $cdnAuthId;
+
+    /**
+     * Secret used to authenticate with test stack CDNs via a custom header
+     *
+     * @var string
+     */
+    private $cdnAuthSecret;
+
+    /**
      * Client configuration data
      *
      * @var array{'base_uri': array<String, String>, 'timeout': ?float, 'handler': ?callable}
@@ -95,16 +109,25 @@ class Sdk
      * @param array<String, mixed> $args Client configuration arguments
      * @param string    $appId          Client application ID
      * @param string    $appPassword    Client application password
+     * @param string    $cdnAuthId      Client identifier used to identify the application to test stack CDNs
+     * @param string    $cdnAuthSecret  Secret used to authenticate with test stack CDNs via a custom header
      *
      * @return void
      *
      * @throws InvalidArgumentException If any required options are missing or
      *                                   an invalid value is provided.
      */
-    final public function __construct(array $args, string $appId = '', string $appPassword = '')
-    {
+    final public function __construct(
+        array $args,
+        string $appId = '',
+        string $appPassword = '',
+        string $cdnAuthId = '',
+        string $cdnAuthSecret = ''
+    ) {
         $this->appId = $appId;
         $this->appPassword = $appPassword;
+        $this->cdnAuthId = $cdnAuthId;
+        $this->cdnAuthSecret = $cdnAuthSecret;
 
         if (isset($args['timeout'])) {
             if (!is_float($args['timeout'])) {
@@ -231,6 +254,8 @@ class Sdk
      * @param callable|null $guzzleHander   Function that transfers HTTP requests over the wire. Passed to Guzzle
      *                                      clients to override the default handler (eg. to use a mock handler).
      *                                      See the Guzzle docs for more info.
+     * @param string $cdnAuthId             Client identifier used to identify the application to test stack CDNs
+     * @param string $cdnAuthSecret         Secret used to authenticate with test stack CDNs via a custom header
      *
      * @link http://guzzle.readthedocs.io/en/latest/quickstart.html Guzzle documentation
      *
@@ -241,7 +266,9 @@ class Sdk
         string $appId,
         string $appPassword,
         ?float $timeout = null,
-        ?callable $guzzleHander = null
+        ?callable $guzzleHander = null,
+        string $cdnAuthId = '',
+        string $cdnAuthSecret = ''
     ): self {
         $args = [
             self::BASE_URI => [
@@ -260,7 +287,7 @@ class Sdk
         if ($guzzleHander !== null) {
             $args['handler'] = $guzzleHander;
         }
-        return new static($args, $appId, $appPassword);
+        return new static($args, $appId, $appPassword, $cdnAuthId, $cdnAuthSecret);
     }
 
     /**
@@ -341,7 +368,7 @@ class Sdk
      */
     private function createClient(string $className)
     {
-        return new $className($this->config, $this->appId, $this->appPassword);
+        return new $className($this->config, $this->appId, $this->appPassword, $this->cdnAuthId, $this->cdnAuthSecret);
     }
 
     /**
@@ -416,5 +443,49 @@ class Sdk
             self::BASE_URI_NOTIFICATIONS => $notificationsServiceBaseUri,
             self::BASE_URI_REWARDS => $rewardsServiceBaseUri
         ];
+    }
+
+    /**
+     * Returns the client identifier used to identify the application to test stack CDNs via a custom header
+     *
+     * @return string Client identifier used to identify the application to test stack CDNs
+     */
+    public function getCdnAuthId(): string
+    {
+        return $this->cdnAuthId;
+    }
+
+    /**
+     * Returns the ID used to identify this application to test stack CDNs
+     *
+     * @param string $cdnAuthId Client identifier used to identify the application to test stack CDNs
+     * @return $this
+     */
+    public function setCdnAuthId(string $cdnAuthId): self
+    {
+        $this->cdnAuthId = $cdnAuthId;
+        return $this;
+    }
+
+    /**
+     * Returns the secret used to authenticate with test stack CDNs via a custom header
+     *
+     * @return string
+     */
+    public function getCdnAuthSecret(): string
+    {
+        return $this->cdnAuthSecret;
+    }
+
+    /**
+     * Set the secret used to authenticate with test stack CDNs via a custom header for all requests made using the SDK
+     *
+     * @param string $cdnAuthSecret Secret used to authenticate with test stack CDNs via a custom header
+     * @return $this
+     */
+    public function setCdnAuthSecret(string $cdnAuthSecret): self
+    {
+        $this->cdnAuthSecret = $cdnAuthSecret;
+        return $this;
     }
 }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Serato\SwsSdk\Test;
 
+use Serato\SwsSdk\Command;
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Client;
 use Serato\SwsSdk\Sdk;
@@ -255,6 +256,24 @@ class ClientTest extends AbstractTestCase
         $clientMock->getProduct($this->getCommandArgs());
     }
 
+    /**
+     * Tests that setting the $cdnAuthSecret constructor argument results in an x-serato-cdn-auth header being added to
+     * requests.
+     *
+     * @return void
+     */
+    public function testClientRequestCdnAuthHeader(): void
+    {
+        $clientMock = $this->getMockClient([$this->getMock200Response()]);
+        $command = $clientMock->getCommand(self::BASIC_AUTH_COMMAND_NAME, $this->getCommandArgs());
+        $request = $command->getRequest();
+
+        $cdnAuthHeader = $request->getHeaderLine(Command::CUSTOM_CDN_AUTH_HEADER);
+        $decodedHeader = base64_decode($cdnAuthHeader);
+        $this->assertNotFalse($decodedHeader, 'x-serato-cdn-auth header should be a base-64-encoded string');
+        $this->assertEquals('my_cdn_client_id:my_cdn_secret', $decodedHeader);
+    }
+
     protected function getMock200Response(): Response
     {
         return new Response(
@@ -292,7 +311,7 @@ class ClientTest extends AbstractTestCase
 
         $clientMock = $this->getMockForAbstractClass(
             Client::class,
-            [$args, 'my_app', 'my_pass']
+            [$args, 'my_app', 'my_pass', 'my_cdn_client_id', 'my_cdn_secret']
         );
 
         $clientMock->expects($this->any())

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -121,6 +121,28 @@ class CommandTest extends AbstractTestCase
         $this->assertRegExp(FirewallHeader::HEADER_PATTERN, $firewallHeader);
     }
 
+    public function testCommandCdnAuthHeader(): void
+    {
+        $this->createCommandMock('http', 'myhost');
+
+        $this->commandMock->expects($this->any())
+            ->method('getHttpMethod')
+            ->willReturn('GET');
+        $this->commandMock->expects($this->any())
+            ->method('getUriPath')
+            ->willReturn('/my/path');
+        $this->commandMock->expects($this->any())
+            ->method('getArgsDefinition')
+            ->willReturn([]);
+
+        $request = $this->commandMock->getRequest();
+
+        $cdnAuthHeader = $request->getHeaderLine(Command::CUSTOM_CDN_AUTH_HEADER);
+        $decodedHeader = base64_decode($cdnAuthHeader);
+        $this->assertNotFalse($decodedHeader, 'x-serato-cdn-auth header should be a base-64-encoded string');
+        $this->assertEquals('my_cdn_client_id:my_cdn_secret', $decodedHeader);
+    }
+
     /**
      * @return array<array<mixed>>>
      */
@@ -225,7 +247,9 @@ class CommandTest extends AbstractTestCase
                 'my_app',
                 'my_pass',
                 $httpScheme . '://' . $httpHost,
-                $commandArgs
+                $commandArgs,
+                'my_cdn_client_id',
+                'my_cdn_secret'
             ]
         );
     }


### PR DESCRIPTION
https://serato.atlassian.net/browse/TDO-372

These changes allow client apps to access test stack CDNs by providing credentials via a custom `x-serato-cdn-auth` header.

- Add test stack CDN auth ID and secret as constructor arguments for the `Command` class. These arguments are optional.
- Flow-on changes to `Client` and `Sdk` classes to provide these credentials to `Command` instances
- Add `x-serato-cdn-auth` header to all requests sent via the `Command` class and subclasses

The `x-serato-cdn-auth` header value is a base-64-encoded string, similar to a basic auth header: `username:password`. 