### PR TITLE
Remove all unused GET request bodies from commands

### DIFF
--- a/src/Ecom/Command/InvoicesSummary.php
+++ b/src/Ecom/Command/InvoicesSummary.php
@@ -21,14 +21,6 @@ class InvoicesSummary extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        return $this->arrayToFormUrlEncodedBody($this->commandArgs);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/Ecom/Command/SubscriptionList.php
+++ b/src/Ecom/Command/SubscriptionList.php
@@ -21,14 +21,6 @@ class SubscriptionList extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        return $this->arrayToFormUrlEncodedBody($this->commandArgs);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/Ecom/Command/VoucherList.php
+++ b/src/Ecom/Command/VoucherList.php
@@ -21,16 +21,6 @@ class VoucherList extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        $args = $this->commandArgs;
-        unset($args['user_id']);
-        return $this->arrayToFormUrlEncodedBody($args);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/Ecom/Command/VoucherTypeList.php
+++ b/src/Ecom/Command/VoucherTypeList.php
@@ -22,14 +22,6 @@ class VoucherTypeList extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        return $this->arrayToFormUrlEncodedBody($this->commandArgs);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/License/Command/LicenseList.php
+++ b/src/License/Command/LicenseList.php
@@ -24,16 +24,6 @@ class LicenseList extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        $args = $this->commandArgs;
-        unset($args['user_id']);
-        return $this->arrayToFormUrlEncodedBody($args);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/Profile/Command/UserGet.php
+++ b/src/Profile/Command/UserGet.php
@@ -21,16 +21,6 @@ class UserGet extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        $args = $this->commandArgs;
-        unset($args['user_id']);
-        return $this->arrayToFormUrlEncodedBody($args);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';

--- a/src/Profile/Command/UserGetBetaProgram.php
+++ b/src/Profile/Command/UserGetBetaProgram.php
@@ -18,16 +18,6 @@ use Serato\SwsSdk\CommandBasicAuth;
  */
 class UserGetBetaProgram extends CommandBasicAuth
 {
-     /**
-     * {@inheritdoc}
-     */
-    public function getBody(): string
-    {
-        $args = $this->commandArgs;
-        unset($args['user_id']);
-        return $this->arrayToFormUrlEncodedBody($args);
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Rewards/Command/RefereeActivityList.php
+++ b/src/Rewards/Command/RefereeActivityList.php
@@ -17,14 +17,6 @@ class RefereeActivityList extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
-    public function getBody(): string
-    {
-        return $this->arrayToFormUrlEncodedBody($this->commandArgs);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getHttpMethod(): string
     {
         return 'GET';


### PR DESCRIPTION
- Remove overrides of `getBody()` in commands that represent GET requests. This falls back to the parent class implementation, where `getBody()` returns null.

CloudFront returns a 403 response if it receives a GET request with a body. (Behaviour for GET requests with bodies is undefined in the RFC.) 