### PR TITLE
[WEB-9464] Order and Invoice data model refactor - Phase 3 of 6

### DIFF
--- a/src/Ecom/Command/InvoiceCreate.php
+++ b/src/Ecom/Command/InvoiceCreate.php
@@ -36,7 +36,9 @@ class InvoiceCreate extends CommandBasicAuth
     protected function getArgsDefinition(): array
     {
         return [
-            'order_id' => ['type' => self::ARG_TYPE_INTEGER, 'required' => true]
+            'order_id' => ['type' => self::ARG_TYPE_INTEGER, 'required' => true],
+            'transaction_reference' => ['type' => self::ARG_TYPE_STRING, 'required' => true],
+            'payment_instrument_transaction_reference' => ['type' => self::ARG_TYPE_STRING, 'required' => false]
         ];
     }
 }

--- a/tests/Ecom/Command/InvoiceCreateTest.php
+++ b/tests/Ecom/Command/InvoiceCreateTest.php
@@ -52,7 +52,11 @@ class InvoiceCreateTest extends AbstractTestCase
             'app_id',
             'app_password',
             'http://my.server.com',
-            ['order_id' => $orderId]
+            [
+                'order_id' => $orderId,
+                'transaction_reference' => 'mock_transaction_ref',
+                'payment_instrument_transaction_reference' => 'mock_payment_instrument_transaction_ref'
+            ]
         );
 
         $request = $command->getRequest();

--- a/tests/Ecom/EcomClientTest.php
+++ b/tests/Ecom/EcomClientTest.php
@@ -60,7 +60,13 @@ class EcomClientTest extends AbstractTestCase
     {
         $body = '{"var1":"val1"}';
         $client = $this->getSdkWithMocked200Response($body)->createEcomClient();
-        $result = $client->createInvoice(['order_id' => 123]);
+        $result = $client->createInvoice(
+            [
+                'order_id' => 123,
+                'transaction_reference' => 'mock_transaction_ref',
+                'payment_instrument_transaction_reference' => 'mock_payment_instrument_transaction_ref'
+            ]
+        );
         $this->assertEquals(
             (string)$this->getResponseObjectFromResult($result)->getBody(),
             $body


### PR DESCRIPTION
- Update `POST /orders/:order_id/invoice` endpoint to add `transaction_reference` and `payment_instrument_transaction_reference` parameters