### PR TITLE
[WEB-9464-bugfix] Order and Invoice data model refactor - Phase 3 of 6

### DIFF
--- a/src/Ecom/Command/InvoiceCreate.php
+++ b/src/Ecom/Command/InvoiceCreate.php
@@ -17,6 +17,16 @@ class InvoiceCreate extends CommandBasicAuth
     /**
      * {@inheritdoc}
      */
+    public function getBody()
+    {
+        $args = $this->commandArgs;
+        unset($args['order_id']);
+        return $this->arrayToFormUrlEncodedBody($args);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getHttpMethod(): string
     {
         return 'POST';
@@ -28,6 +38,14 @@ class InvoiceCreate extends CommandBasicAuth
     public function getUriPath(): string
     {
         return '/api/v1/orders/' . self::toString($this->commandArgs['order_id']) . '/invoice';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setCommandRequestHeaders(): void
+    {
+        $this->setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
     }
 
     /**

--- a/tests/Ecom/Command/InvoiceCreateTest.php
+++ b/tests/Ecom/Command/InvoiceCreateTest.php
@@ -48,20 +48,29 @@ class InvoiceCreateTest extends AbstractTestCase
     public function testSmokeTest(): void
     {
         $orderId = 123;
+
+        $args = [
+            'order_id' => $orderId,
+            'transaction_reference' => 'mock_transaction_ref',
+            'payment_instrument_transaction_reference' => 'mock_payment_instrument_transaction_ref'
+        ];
+
         $command = new InvoiceCreate(
             'app_id',
             'app_password',
             'http://my.server.com',
-            [
-                'order_id' => $orderId,
-                'transaction_reference' => 'mock_transaction_ref',
-                'payment_instrument_transaction_reference' => 'mock_payment_instrument_transaction_ref'
-            ]
+            $args
         );
 
         $request = $command->getRequest();
+        parse_str((string) $request->getBody(), $bodyParams);
+
         $this->assertEquals('POST', $request->getMethod());
         $this->assertRegExp('/^Basic [[:alnum:]=]+$/', $request->getHeaderLine('Authorization'));
         $this->assertStringEndsWith("/api/v1/orders/{$orderId}/invoice", $request->getUri()->getPath());
+
+        unset($args['order_id']);
+        $expectedBodyParams = $args;
+        $this->assertEquals($expectedBodyParams, $bodyParams);
     }
 }


### PR DESCRIPTION
- Fix bug that request header and body functions are missed in the `POST /orders/:order_id/invoice` endpoint.