### PR TITLE
[WEB-10582] Implement Refresh Token Rotation for `serato.com`

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -19,6 +19,7 @@ abstract class Command
     public const ARG_TYPE_STRING   = 'string';
     public const ARG_TYPE_INTEGER  = 'integer';
     public const ARG_TYPE_DATETIME = 'datetime';
+    public const ARG_TYPE_BOOLEAN = 'boolean';
 
     /**
      * The custom header that identifies requests from the SDK to the application firewall
@@ -69,7 +70,7 @@ abstract class Command
     /**
      * Command arguments (specified as name/value pairs)
      *
-     * @var array<String, String|Integer|DateTime>
+     * @var array<String, String|Integer|DateTime|Boolean>
      */
     protected $commandArgs = [];
 
@@ -88,7 +89,7 @@ abstract class Command
      * @param string    $baseUri        Base request URI
      * @param string    $cdnAuthId      Client identifier used to identify the application to test stack CDNs
      * @param string    $cdnAuthSecret  Secret used to authenticate requests to test stack CDNs
-     * @param array<String, String|Integer|DateTime>     $args           Command arguments
+     * @param array<String, String|Integer|DateTime|Boolean>     $args           Command arguments
      */
     public function __construct(
         string $appId,
@@ -108,9 +109,9 @@ abstract class Command
 
     /**
      * Casts values to a string. Supports any of the allowable command paramter types.
-     * ie. String, Integer, DateTime
+     * ie. String, Integer, DateTime, Boolean
      *
-     * @param String|Integer|DateTime $value
+     * @param String|Integer|DateTime|Boolean $value
      * @return string
      * @throws InvalidArgumentException
      */
@@ -122,9 +123,11 @@ abstract class Command
             return (string)$value;
         } elseif (is_a($value, DateTime::class)) {
             return $value->format(DateTime::ATOM);
+        } elseif (is_bool($value)) {
+            return (string)$value;
         }
         throw new InvalidArgumentException(
-            'Invalid argment type. Only string, integer and DateTime types are supported'
+            'Invalid argment type. Only string, integer, boolean and DateTime types are supported'
         );
     }
 
@@ -174,6 +177,11 @@ abstract class Command
                     case self::ARG_TYPE_DATETIME:
                         if (is_int($value) || !is_a($value, '\DateTime')) {
                             throw new InvalidArgumentException("Command arg `$name` must be of type DateTime");
+                        }
+                        break;
+                    case self::ARG_TYPE_BOOLEAN:
+                        if (!is_bool($value)) {
+                            throw new InvalidArgumentException("Command arg `$name` must be of type boolean");
                         }
                         break;
                 }

--- a/src/Identity/Command/TokenRefresh.php
+++ b/src/Identity/Command/TokenRefresh.php
@@ -12,6 +12,7 @@ use Serato\SwsSdk\CommandBasicAuth;
  * Valid keys for the `$args` array provided to the constructor are:
  *
  * - `refresh_token`: (string) Required. A valid refresh token.
+ * - `use_rotation`: (boolean) When true, rotates the refresh token on every call. Default it is true.
  *
  * This command can be executed on a `Serato\SwsSdk\Identity\IdentityClient` instance
  * using the `IdentityClient::tokenRefresh` magic method.
@@ -39,7 +40,12 @@ class TokenRefresh extends CommandBasicAuth
      */
     public function getUriPath(): string
     {
-        return '/api/v1/tokens/refresh';
+        // By default we use token rotation if it is not set
+        $useRotation = true;
+        if (isset($this->commandArgs['use_rotation'])) {
+            $useRotation = $this->commandArgs['use_rotation'];
+        }
+        return $useRotation ? '/api/v2/tokens/refresh' : '/api/v1/tokens/refresh';
     }
 
     /**
@@ -56,7 +62,8 @@ class TokenRefresh extends CommandBasicAuth
     protected function getArgsDefinition(): array
     {
         return [
-            'refresh_token' => ['type' => self::ARG_TYPE_STRING, 'required' => true]
+            'refresh_token' => ['type' => self::ARG_TYPE_STRING, 'required' => true],
+            'use_rotation'  => ['type' => self::ARG_TYPE_BOOLEAN, 'required' => false]
         ];
     }
 }

--- a/tests/Identity/Command/TokenRefreshTest.php
+++ b/tests/Identity/Command/TokenRefreshTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Serato\SwsSdk\Test\Identity\Command;
+
+use Serato\SwsSdk\Test\AbstractTestCase;
+use Serato\SwsSdk\Identity\Command\TokenRefresh;
+use GuzzleHttp\Psr7\Uri;
+
+class TokenRefreshTest extends AbstractTestCase
+{
+    /**
+     * @param array<mixed> $args
+     * @return void
+     *
+     * @dataProvider missingRequiredArgProvider
+     *
+     *
+     */
+    public function testMissingRequiredArg(array $args): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $command = new TokenRefresh(
+            'app_id',
+            'app_password',
+            'http://my.server.com',
+            $args
+        );
+
+        $command->getRequest();
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function missingRequiredArgProvider(): array
+    {
+        return [
+            [[]],
+            [['use_rotation' => true]]
+        ];
+    }
+
+    public function testSmokeTest(): void
+    {
+        $refreshToken = 'refresh_token';
+
+        $command = new TokenRefresh(
+            'app_id',
+            'app_password',
+            'http://my.server.com',
+            ['refresh_token' => $refreshToken]
+        );
+
+        $request = $command->getRequest();
+        parse_str((string)$request->getBody(), $bodyParams);
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertRegExp('/^\/api\/v2\/tokens\/refresh$/', $request->getUri()->getPath());
+        $this->assertRegExp('/^Basic [[:alnum:]=]+$/', $request->getHeaderLine('Authorization'));
+        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals($refreshToken, $bodyParams['refresh_token']);
+    }
+
+    /**
+     * @param bool $useRotation
+     * @param string $expectedUrlRegex
+     * @return void
+     * @dataProvider useTokenRotationProvider
+     */
+    public function testUseTokenRotationTest($useRotation, $expectedUrlRegex): void
+    {
+        $refreshToken = 'refresh_token';
+
+        $command = new TokenRefresh(
+            'app_id',
+            'app_password',
+            'http://my.server.com',
+            ['refresh_token' => $refreshToken, 'use_rotation' => $useRotation]
+        );
+
+        $request = $command->getRequest();
+        parse_str((string)$request->getBody(), $bodyParams);
+        $this->assertEquals('POST', $request->getMethod());
+        $this->assertRegExp($expectedUrlRegex, $request->getUri()->getPath());
+        $this->assertRegExp('/^Basic [[:alnum:]=]+$/', $request->getHeaderLine('Authorization'));
+        $this->assertEquals('application/x-www-form-urlencoded', $request->getHeaderLine('Content-Type'));
+        $this->assertEquals($refreshToken, $bodyParams['refresh_token']);
+        $this->assertEquals($useRotation, $bodyParams['use_rotation']);
+    }
+
+    /**
+     * @return array<array<mixed>>
+     */
+    public function useTokenRotationProvider(): array
+    {
+        return [
+            ['useRotation' => false, 'expectedUrlRegex' => '/^\/api\/v1\/tokens\/refresh$/' ],
+            ['useRotation' => true, 'expectedUrlRegex' => '/^\/api\/v2\/tokens\/refresh$/' ],
+        ];
+    }
+}

--- a/tests/Identity/Command/TokenRefreshTest.php
+++ b/tests/Identity/Command/TokenRefreshTest.php
@@ -6,7 +6,6 @@ namespace Serato\SwsSdk\Test\Identity\Command;
 
 use Serato\SwsSdk\Test\AbstractTestCase;
 use Serato\SwsSdk\Identity\Command\TokenRefresh;
-use GuzzleHttp\Psr7\Uri;
 
 class TokenRefreshTest extends AbstractTestCase
 {
@@ -15,8 +14,6 @@ class TokenRefreshTest extends AbstractTestCase
      * @return void
      *
      * @dataProvider missingRequiredArgProvider
-     *
-     *
      */
     public function testMissingRequiredArg(array $args): void
     {


### PR DESCRIPTION
- Add functionality to toggle between using new and old token refresh endpoint.
  - had to add a new arg type to handle booleans
- Add token refresh tests